### PR TITLE
Handle non-constant entries in .rodata section

### DIFF
--- a/src/assembly/parse/addressing.rs
+++ b/src/assembly/parse/addressing.rs
@@ -191,12 +191,11 @@ pub(crate) fn parse_relative_addressing<'a>(
             let (_, operand) = parse_absolute_addressing_from_list(addressing_mode, tmp)?;
 
             operand
-        }
-        // GenericOperand {
-        //     r#type: operand,
-        //     immediate: imm,
-        //     register: reg,
-        // },
+        } // GenericOperand {
+          //     r#type: operand,
+          //     immediate: imm,
+          //     register: reg,
+          // },
     };
 
     Ok((rest, operand))

--- a/src/assembly/section/mod.rs
+++ b/src/assembly/section/mod.rs
@@ -66,7 +66,7 @@ pub(crate) struct DataSection {
 
 #[derive(Clone, Debug)]
 pub(crate) enum DataSectionElement {
-    Unlabeled(ConstantElement),
+    Unlabeled(DataElement),
     Labeled(LabeledConstant),
 }
 
@@ -74,13 +74,13 @@ pub(crate) enum DataSectionElement {
 pub(crate) struct LabeledConstant {
     pub(crate) label: String,
     pub(crate) source_line: usize,
-    pub(crate) content: Vec<ConstantValue>,
+    pub(crate) content: Vec<DataElement>,
 }
 
 #[derive(Clone, Debug)]
-pub(crate) struct ConstantElement {
-    pub(crate) source_line: usize,
-    pub(crate) content_type: ConstantValue,
+pub(crate) enum DataElement {
+    LabelName(String),
+    Constant(ConstantValue),
 }
 
 // Globals section can only containt named globals
@@ -91,7 +91,7 @@ pub(crate) struct GlobalsSection {
 
 #[derive(Clone, Debug)]
 pub(crate) enum GlobalsSectionElement {
-    Unlabeled(ConstantElement),
+    Unlabeled(ConstantValue),
     Labeled(LabeledGlobal),
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -37,6 +37,8 @@ pub enum AssemblyParseError {
     DuplicateLabel(String),
     #[error("there is no label `{0}` in data section of functions")]
     LabelNotFound(String),
+    #[error("failed to resolve relocation for label `{0}` in data section")]
+    RelocationError(String),
     #[error("Label {1} was tried to be used for either PC or constant at offset {0} that is more than `{2}` addressable space")]
     CodeIsTooLong(usize, String, u64),
 }


### PR DESCRIPTION
# What ❔

This patch adds support for handling non-constant entries in .rodata section that LLVM compiler can now generate.
<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

This is to enable handling of jump table entries in the .rodata section.
<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
